### PR TITLE
package-info.class files inside org.eclipse.parsson:jakarta.json are compiled with the wrong Java version #73

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <release>9</release>
+		     <!-- Workaround to compile package-info with JDK8 -->
+                    <createMissingPackageInfoClass>false</createMissingPackageInfoClass>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                     </compilerArgs>
@@ -205,6 +207,7 @@
                         </goals>
                         <configuration>
                             <release>8</release>
+                            <createMissingPackageInfoClass>true</createMissingPackageInfoClass>
                             <excludes>
                                 <exclude>module-info.java</exclude>
                             </excludes>


### PR DESCRIPTION
Relates to https://github.com/eclipse-ee4j/parsson/issues/73

To verify the fix:
```
$ mvn clean install
$ javap -verbose -classpath bundles/jakarta.json/target/jakarta.json-1.1.2-SNAPSHOT.jar jakarta.json.package-info | grep version
  minor version: 0
  major version: 52
```

Javadoc of packages are still there, you can verify it opening bundles/jakarta.json/target/site/apidocs/jakarta.json/jakarta/json/package-summary.html

