### PR TITLE
BigInteger scale limit counts absolute value now.

### DIFF
--- a/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
@@ -116,7 +116,11 @@ final class JsonMessages {
     static String PARSER_INPUT_ENC_DETECT_IOERR() {
         return localize("parser.input.enc.detect.ioerr");
     }
-    
+
+    static String PARSER_INPUT_NESTED_TOO_DEEP(int limit) {
+        return localize("parser.input.nested.too.deep", limit);
+    }
+
     static String DUPLICATE_KEY(String name) {
         return localize("parser.duplicate.key", name);
     }

--- a/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
@@ -162,6 +162,10 @@ final class JsonMessages {
         return localize("reader.read.already.called");
     }
 
+    // JSON number messages
+    static String NUMBER_SCALE_LIMIT_EXCEPTION(int value, int limit) {
+        return localize("number.scale.limit.exception", value, limit);
+    }
 
     // obj builder messages
     static String OBJBUILDER_NAME_NULL() {

--- a/impl/src/main/java/org/eclipse/parsson/JsonNumberImpl.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonNumberImpl.java
@@ -28,6 +28,9 @@ import java.math.BigInteger;
  */
 abstract class JsonNumberImpl implements JsonNumber {
 
+    private static final String SCALE_LIMIT_EXCEPTION_MESSAGE
+            = "Scale value %d of this BigInteger exceeded maximal allowed absolute value of %d";
+
     private int hashCode;
     private final int bigIntegerScaleLimit;
 
@@ -287,25 +290,21 @@ abstract class JsonNumberImpl implements JsonNumber {
     @Override
     public BigInteger bigIntegerValue() {
         BigDecimal bd = bigDecimalValue();
-        if (bd.scale() <= bigIntegerScaleLimit) {
+        if (Math.abs(bd.scale()) <= bigIntegerScaleLimit) {
             return bd.toBigInteger();
         }
         throw new UnsupportedOperationException(
-                String.format(
-                        "Scale value %d of this BigInteger exceeded maximal allowed value of %d",
-                        bd.scale(), bigIntegerScaleLimit));
+                String.format(SCALE_LIMIT_EXCEPTION_MESSAGE, bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override
     public BigInteger bigIntegerValueExact() {
         BigDecimal bd = bigDecimalValue();
-        if (bd.scale() <= bigIntegerScaleLimit) {
+        if (Math.abs(bd.scale()) <= bigIntegerScaleLimit) {
             return bd.toBigIntegerExact();
         }
         throw new UnsupportedOperationException(
-                String.format(
-                        "Scale value %d of this BigInteger exceeded maximal allowed value of %d",
-                        bd.scale(), bigIntegerScaleLimit));
+                String.format(SCALE_LIMIT_EXCEPTION_MESSAGE, bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override

--- a/impl/src/main/java/org/eclipse/parsson/JsonNumberImpl.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonNumberImpl.java
@@ -28,9 +28,6 @@ import java.math.BigInteger;
  */
 abstract class JsonNumberImpl implements JsonNumber {
 
-    private static final String SCALE_LIMIT_EXCEPTION_MESSAGE
-            = "Scale value %d of this BigInteger exceeded maximal allowed absolute value of %d";
-
     private int hashCode;
     private final int bigIntegerScaleLimit;
 
@@ -294,7 +291,7 @@ abstract class JsonNumberImpl implements JsonNumber {
             return bd.toBigInteger();
         }
         throw new UnsupportedOperationException(
-                String.format(SCALE_LIMIT_EXCEPTION_MESSAGE, bd.scale(), bigIntegerScaleLimit));
+                JsonMessages.NUMBER_SCALE_LIMIT_EXCEPTION(bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override
@@ -304,7 +301,7 @@ abstract class JsonNumberImpl implements JsonNumber {
             return bd.toBigIntegerExact();
         }
         throw new UnsupportedOperationException(
-                String.format(SCALE_LIMIT_EXCEPTION_MESSAGE, bd.scale(), bigIntegerScaleLimit));
+                JsonMessages.NUMBER_SCALE_LIMIT_EXCEPTION(bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override

--- a/impl/src/main/java/org/eclipse/parsson/JsonParserImpl.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonParserImpl.java
@@ -393,7 +393,7 @@ public class JsonParserImpl implements JsonParser {
 
         private void push(Context context) {
             if (++size >= limit) {
-                throw new RuntimeException("Input is too deeply nested " + size);
+                throw new RuntimeException(JsonMessages.PARSER_INPUT_NESTED_TOO_DEEP(size));
             }
             context.next = head;
             head = context;

--- a/impl/src/main/java/org/eclipse/parsson/api/JsonConfig.java
+++ b/impl/src/main/java/org/eclipse/parsson/api/JsonConfig.java
@@ -19,8 +19,8 @@ package org.eclipse.parsson.api;
 public interface JsonConfig {
 
     /**
-     * Configuration property to limit maximum value of BigInteger scale value.
-     * This property limits maximum value of scale value to be allowed
+     * Configuration property to limit maximum absolute value of BigInteger scale.
+     * This property limits maximum absolute value of scale to be allowed
      * in {@link jakarta.json.JsonNumber#bigIntegerValue()}
      * and {@link jakarta.json.JsonNumber#bigIntegerValueExact()} implemented methods.
      * Default value is set to {@code 100000}.

--- a/impl/src/main/resources/org/eclipse/parsson/messages.properties
+++ b/impl/src/main/resources/org/eclipse/parsson/messages.properties
@@ -58,6 +58,8 @@ writer.write.already.called=write/writeObject/writeArray/close method is already
 
 reader.read.already.called=read/readObject/readArray/close method is already called
 
+number.scale.limit.exception=Scale value {0} of this BigInteger exceeded maximal allowed absolute value of {1}
+
 objbuilder.name.null=Name in JsonObject's name/value pair cannot be null
 objbuilder.value.null=Value in JsonObject's name/value pair cannot be null
 objbuilder.object.builder.null=Object builder that is used to create a value in JsonObject's name/value pair cannot be null

--- a/impl/src/main/resources/org/eclipse/parsson/messages.properties
+++ b/impl/src/main/resources/org/eclipse/parsson/messages.properties
@@ -44,6 +44,7 @@ parser.scope.err=Cannot be called for value {0}
 parser.input.enc.detect.failed=Cannot auto-detect encoding, not enough chars
 parser.input.enc.detect.ioerr=I/O error while auto-detecting the encoding of stream
 parser.duplicate.key=Duplicate key ''{0}'' is not allowed
+parser.input.nested.too.deep=Input is too deeply nested {0}
 
 generator.flush.io.err=I/O error while flushing generated JSON
 generator.close.io.err=I/O error while closing JsonGenerator

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonBigDecimalScaleLimitTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonBigDecimalScaleLimitTest.java
@@ -28,13 +28,15 @@ import org.eclipse.parsson.api.JsonConfig;
  */
 public class JsonBigDecimalScaleLimitTest extends TestCase {
 
+    private static final int MAX_BIGINTEGER_SCALE = 50000;
+
     public JsonBigDecimalScaleLimitTest(String testName) {
         super(testName);
     }
 
     @Override
     protected void setUp() {
-        System.setProperty(JsonConfig.MAX_BIGINTEGER_SCALE, "50000");
+        System.setProperty(JsonConfig.MAX_BIGINTEGER_SCALE, Integer.toString(MAX_BIGINTEGER_SCALE));
     }
 
     @Override
@@ -61,9 +63,8 @@ public class JsonBigDecimalScaleLimitTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value 50001 of this BigInteger exceeded maximal allowed absolute value of 50000",
-                    e.getMessage());
+            JsonNumberTest.assertExceptionMessageContainsNumber(e, 50001);
+            JsonNumberTest.assertExceptionMessageContainsNumber(e, MAX_BIGINTEGER_SCALE);
         }
         System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
     }
@@ -80,9 +81,8 @@ public class JsonBigDecimalScaleLimitTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value -50001 of this BigInteger exceeded maximal allowed absolute value of 50000",
-                    e.getMessage());
+            JsonNumberTest.assertExceptionMessageContainsNumber(e, -50001);
+            JsonNumberTest.assertExceptionMessageContainsNumber(e, MAX_BIGINTEGER_SCALE);
         }
         System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
     }

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonBigDecimalScaleLimitTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonBigDecimalScaleLimitTest.java
@@ -62,7 +62,26 @@ public class JsonBigDecimalScaleLimitTest extends TestCase {
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
             assertEquals(
-                    "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
+                    "Scale value 50001 of this BigInteger exceeded maximal allowed absolute value of 50000",
+                    e.getMessage());
+        }
+        System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
+    }
+
+    // Test BigInteger scale value limit set from system property using value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    // Default value is 100000 and system property lowered it to 50000 so value with scale -50001
+    // test shall fail with exception message matching modified limits.
+    public void testSystemPropertyBigIntegerNegScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(-50001, RoundingMode.HALF_UP);
+        try {
+            Json.createValue(value).bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Scale value -50001 of this BigInteger exceeded maximal allowed absolute value of 50000",
                     e.getMessage());
         }
         System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonNumberTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonNumberTest.java
@@ -21,6 +21,7 @@ import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.text.MessageFormat;
 import java.util.Map;
 
 import jakarta.json.Json;
@@ -60,6 +61,9 @@ public class JsonNumberTest extends TestCase {
 
     // π as JsonNumber with 1101 source characters
     private static final String Π_1101 = Π_1100 + "5";
+
+    // Default maximum value of BigInteger scale value limit from JsonContext
+    private static final int DEFAULT_MAX_BIGINTEGER_SCALE = 100000;
 
     public JsonNumberTest(String testName) {
         super(testName);
@@ -273,7 +277,7 @@ public class JsonNumberTest extends TestCase {
         Json.createValue(value).bigIntegerValue();
     }
 
-    // Test default BigInteger scale value limit using value above limit.
+    // Test default BigInteger scale value limit using positive value above limit.
     // Call shall throw specific UnsupportedOperationException exception.
     public void testDefaultBigIntegerScaleAboveLimit() {
         BigDecimal value = new BigDecimal("3.1415926535897932384626433")
@@ -283,13 +287,12 @@ public class JsonNumberTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value 100001 of this BigInteger exceeded maximal allowed absolute value of 100000",
-                    e.getMessage());
+            assertExceptionMessageContainsNumber(e, 100001);
+            assertExceptionMessageContainsNumber(e, DEFAULT_MAX_BIGINTEGER_SCALE);
         }
     }
 
-    // Test default BigInteger scale value limit using value above limit.
+    // Test default BigInteger scale value limit using negative value above limit.
     // Call shall throw specific UnsupportedOperationException exception.
     public void testDefaultBigIntegerNegScaleAboveLimit() {
         BigDecimal value = new BigDecimal("3.1415926535897932384626433")
@@ -299,9 +302,8 @@ public class JsonNumberTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value -100001 of this BigInteger exceeded maximal allowed absolute value of 100000",
-                    e.getMessage());
+            assertExceptionMessageContainsNumber(e, -100001);
+            assertExceptionMessageContainsNumber(e, DEFAULT_MAX_BIGINTEGER_SCALE);
         }
     }
 
@@ -323,9 +325,8 @@ public class JsonNumberTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value 50001 of this BigInteger exceeded maximal allowed absolute value of 50000",
-                    e.getMessage());
+            assertExceptionMessageContainsNumber(e, 50001);
+            assertExceptionMessageContainsNumber(e, 50000);
         }
     }
 
@@ -347,9 +348,8 @@ public class JsonNumberTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value -50001 of this BigInteger exceeded maximal allowed absolute value of 50000",
-                    e.getMessage());
+            assertExceptionMessageContainsNumber(e, -50001);
+            assertExceptionMessageContainsNumber(e, 50000);
         }
     }
 
@@ -403,6 +403,13 @@ public class JsonNumberTest extends TestCase {
                     "Number of BigDecimal source characters 501 exceeded maximal allowed value of 500",
                     e.getMessage());
         }
+    }
+
+    static void assertExceptionMessageContainsNumber(Exception e, int number) {
+        // Format the number as being written to message from messages bundle
+        String numberString = MessageFormat.format("{0}", number);
+        assertTrue("Substring \"" + numberString + "\" was not found in \"" + e.getMessage() + "\"",
+                   e.getMessage().contains(numberString));
     }
 
     private static class CustomNumber extends Number {

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonNumberTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonNumberTest.java
@@ -284,7 +284,23 @@ public class JsonNumberTest extends TestCase {
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
             assertEquals(
-                    "Scale value 100001 of this BigInteger exceeded maximal allowed value of 100000",
+                    "Scale value 100001 of this BigInteger exceeded maximal allowed absolute value of 100000",
+                    e.getMessage());
+        }
+    }
+
+    // Test default BigInteger scale value limit using value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    public void testDefaultBigIntegerNegScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(-100001, RoundingMode.HALF_UP);
+        try {
+            Json.createValue(value).bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Scale value -100001 of this BigInteger exceeded maximal allowed absolute value of 100000",
                     e.getMessage());
         }
     }
@@ -308,7 +324,31 @@ public class JsonNumberTest extends TestCase {
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
             assertEquals(
-                    "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
+                    "Scale value 50001 of this BigInteger exceeded maximal allowed absolute value of 50000",
+                    e.getMessage());
+        }
+    }
+
+    // Test BigInteger scale value limit set from config Map using value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    // Config Map limit is stored in target JsonObject and shall be present for later value manipulation.
+    // Default value is 100000 and config Map property lowered it to 50000 so value with scale -50001
+    // test shall fail with exception message matching modified limits.
+    public void testConfigBigIntegerNegScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(-50001, RoundingMode.HALF_UP);
+        Map<String, ?> config = Map.of(JsonConfig.MAX_BIGINTEGER_SCALE, "50000");
+        try {
+            JsonObject jsonObject = Json.createBuilderFactory(config)
+                    .createObjectBuilder()
+                    .add("bigDecimal", value)
+                    .build();
+            jsonObject.getJsonNumber("bigDecimal").bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Scale value -50001 of this BigInteger exceeded maximal allowed absolute value of 50000",
                     e.getMessage());
         }
     }


### PR DESCRIPTION
Changed contition to count `Math.abs(bd.scale())`
Added tests with negative scale values.