### PR TITLE
Corrupted OSGi manifest header fix

### DIFF
--- a/bundles/jakarta.json/pom.xml
+++ b/bundles/jakarta.json/pom.xml
@@ -177,8 +177,7 @@
                             osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.processor)
                               (version>=1.0.0)(!(version>=2.0.0)))";resolution:=optional,
                             osgi.serviceloader;
-                              filter:="(osgi.serviceloader=jakarta.json.spi.JsonProvider";
-                                osgi.serviceloader="jakarta.json.spi.JsonProvider";
+                              filter:="(osgi.serviceloader=jakarta.json.spi.JsonProvider)";
                                 cardinality:=multiple;resolution:=optional
                             ]]>
                                 </Require-Capability>


### PR DESCRIPTION
Latest two versions of `org.eclipse.parsson.jakarta.json` (`org.eclipse.parsson:jakarta.json:1.1.4` and `org.eclipse.parsson:jakarta.json:1.1.3`) had corrupted OSGi manifest header, preventing their use in OSGi projects.

Please see https://github.com/eclipse-ee4j/parsson/issues/106 for more details.