### PR TITLE
Enable jakarta.json.provider system property to work in JPMS apps. Pr…

### DIFF
--- a/impl/src/main/java/module-info.java
+++ b/impl/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,5 +20,6 @@
 module org.eclipse.parsson {
     requires transitive jakarta.json;
     exports org.eclipse.parsson.api;
+    opens org.eclipse.parsson to jakarta.json;
     provides jakarta.json.spi.JsonProvider with org.eclipse.parsson.JsonProviderImpl;
 }


### PR DESCRIPTION
https://github.com/eclipse-ee4j/parsson/issues/129

I think we don't have tests for this kind of module visibility issues. We should have a new maven module to simulate user usages (with different module name and package names).

We cannot test this under `parsson/impl/src/test/java`.