### PR TITLE
Fix copyright year in JsonArrayBuilderImpl

### DIFF
--- a/impl/src/main/java/org/eclipse/parsson/JsonArrayBuilderImpl.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonArrayBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
In #135 I forgot to update the copyright year, this PR fixes that.