### PR TITLE
Optimize skip methods of JsonStructureParser

### DIFF
--- a/impl/src/main/java/org/eclipse/parsson/JsonStructureParser.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonStructureParser.java
@@ -158,56 +158,14 @@ class JsonStructureParser implements JsonParser {
     @Override
     public void skipObject() {
         if (current instanceof ObjectScope) {
-            int depth = 1;
-            do {
-                if (state == Event.KEY_NAME) {
-                    state = getState(current.getJsonValue());
-                    switch (state) {
-                        case START_OBJECT:
-                            depth++;
-                            break;
-                        case END_OBJECT:
-                            depth--;
-                            break;
-                        default:
-                            //no-op
-                    }
-                } else {
-                    if (current.hasNext()) {
-                        current.next();
-                        state = Event.KEY_NAME;
-                    } else {
-                        state = Event.END_OBJECT;
-                        depth--;
-                    }
-                }
-            } while (state != Event.END_OBJECT && depth > 0);
+            state = Event.END_OBJECT;
         }
     }
 
     @Override
     public void skipArray() {
         if (current instanceof ArrayScope) {
-            int depth = 1;
-            do {
-                if (current.hasNext()) {
-                    current.next();
-                    state = getState(current.getJsonValue());
-                    switch (state) {
-                        case START_ARRAY:
-                            depth++;
-                            break;
-                        case END_ARRAY:
-                            depth--;
-                            break;
-                        default:
-                            //no-op
-                    }
-                } else {
-                    state = Event.END_ARRAY;
-                    depth--;
-                }
-            } while (!(state == Event.END_ARRAY && depth == 0));
+            state = Event.END_ARRAY;
         }
     }
 

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonParserTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonParserTest.java
@@ -886,4 +886,49 @@ public class JsonParserTest {
         }
         Assertions.fail();
     }
+
+    @Test
+    void testSkipStructure() {
+        try (JsonParser parser = Json.createParserFactory(null).createParser(
+                Json.createArrayBuilder()
+                        .add(1)
+                        .add(Json.createArrayBuilder()
+                                .add(2)
+                                .build())
+                        .add(3)
+                        .add(Json.createObjectBuilder()
+                                .add("key", 4)
+                                .build())
+                        .add(5)
+                        .add(6)
+                        .build())) {
+            testSkipStructure(parser);
+        }
+    }
+
+    static void testSkipStructure(JsonParser parser) {
+        Assertions.assertEquals(Event.START_ARRAY, parser.next());
+        Assertions.assertEquals(Event.VALUE_NUMBER, parser.next());
+        Assertions.assertEquals(1, parser.getInt());
+
+        Assertions.assertEquals(Event.START_ARRAY, parser.next());
+        parser.skipArray();
+        Assertions.assertEquals(Event.END_ARRAY, parser.currentEvent());
+
+        Assertions.assertEquals(Event.VALUE_NUMBER, parser.next());
+        Assertions.assertEquals(3, parser.getInt());
+
+        Assertions.assertEquals(Event.START_OBJECT, parser.next());
+        parser.skipObject();
+        Assertions.assertEquals(Event.END_OBJECT, parser.currentEvent());
+
+        Assertions.assertEquals(Event.VALUE_NUMBER, parser.next());
+        Assertions.assertEquals(5, parser.getInt());
+
+        Assertions.assertEquals(Event.VALUE_NUMBER, parser.next());
+        Assertions.assertEquals(6, parser.getInt());
+
+        Assertions.assertEquals(Event.END_ARRAY, parser.next());
+        Assertions.assertFalse(parser.hasNext());
+    }
 }


### PR DESCRIPTION
Optimize the following methods in JsonStructureParser

- skipObject
- skipArray