### PR TITLE
Use convenience factory methods for collections

### DIFF
--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonBuilderTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonBuilderTest.java
@@ -101,7 +101,7 @@ public class JsonBuilderTest {
         person.put("lastName", "Smith");
         person.put("age", 25);
 
-        Map<String, Object> address = Optional.of(new HashMap<String, Object>()).get();
+        Map<String, Object> address = new HashMap<>();
         address.put("streetAddress", "21 2nd Street");
         address.put("city", "New York");
         address.put("state", "NY");

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonGeneratorTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonGeneratorTest.java
@@ -499,9 +499,7 @@ public class JsonGeneratorTest {
     @Test
     void testBufferPoolFeature() {
         final JsonParserTest.MyBufferPool bufferPool = new JsonParserTest.MyBufferPool(1024);
-        Map<String, Object> config = new HashMap<String, Object>() {{
-            put(BufferPool.class.getName(), bufferPool);
-        }};
+        Map<String, Object> config = Map.of(BufferPool.class.getName(), bufferPool);
 
         JsonGeneratorFactory factory = Json.createGeneratorFactory(config);
         JsonGenerator generator = factory.createGenerator(new StringWriter());
@@ -518,9 +516,7 @@ public class JsonGeneratorTest {
         JsonBuilderFactory bf = Json.createBuilderFactory(null);
         for(int size=10; size < 1000; size++) {
             final JsonParserTest.MyBufferPool bufferPool = new JsonParserTest.MyBufferPool(size);
-            Map<String, Object> config = new HashMap<String, Object>() {{
-                put(BufferPool.class.getName(), bufferPool);
-            }};
+            Map<String, Object> config = Map.of(BufferPool.class.getName(), bufferPool);
             JsonGeneratorFactory gf = Json.createGeneratorFactory(config);
 
             StringBuilder sb = new StringBuilder();

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonParserTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonParserTest.java
@@ -693,9 +693,7 @@ public class JsonParserTest {
     @Test
     void testBufferPoolFeature() {
         final MyBufferPool bufferPool = new MyBufferPool(1024);
-        Map<String, Object> config = new HashMap<String, Object>() {{
-            put(BufferPool.class.getName(), bufferPool);
-        }};
+        Map<String, Object> config = Map.of(BufferPool.class.getName(), bufferPool);
 
         JsonParserFactory factory = Json.createParserFactory(config);
         try (JsonParser parser = factory.createParser(new StringReader("[]"))) {
@@ -711,9 +709,7 @@ public class JsonParserTest {
         Random r = new Random(System.currentTimeMillis());
         for(int size=100; size < 1000; size++) {
             final MyBufferPool bufferPool = new MyBufferPool(size);
-            Map<String, Object> config = new HashMap<String, Object>() {{
-                put(BufferPool.class.getName(), bufferPool);
-            }};
+            Map<String, Object> config = Map.of(BufferPool.class.getName(), bufferPool);
             JsonParserFactory factory = Json.createParserFactory(config);
 
             StringBuilder sb = new StringBuilder();
@@ -790,9 +786,7 @@ public class JsonParserTest {
     void testStringUsingBuffers() throws Throwable {
         for(int size=20; size < 500; size++) {
             final MyBufferPool bufferPool = new MyBufferPool(size);
-            Map<String, Object> config = new HashMap<String, Object>() {{
-                put(BufferPool.class.getName(), bufferPool);
-            }};
+            Map<String, Object> config = Map.of(BufferPool.class.getName(), bufferPool);
             JsonParserFactory factory = Json.createParserFactory(config);
 
             StringBuilder sb = new StringBuilder();

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonReaderTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonReaderTest.java
@@ -254,9 +254,7 @@ public class JsonReaderTest {
     void testEmptyStringUsingBuffers() throws Throwable {
         for(int size=20; size < 500; size++) {
             final JsonParserTest.MyBufferPool bufferPool = new JsonParserTest.MyBufferPool(size);
-            Map<String, Object> config = new HashMap<String, Object>() {{
-                put(BufferPool.class.getName(), bufferPool);
-            }};
+            Map<String, Object> config = Map.of(BufferPool.class.getName(), bufferPool);
             JsonReaderFactory factory = Json.createReaderFactory(config);
 
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Use convenience factory methods for collections instead of double brace initialization.