### PR TITLE
Adding Dependabot for dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: maven
+    directory: /impl
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gradle
+    directory: /tck-impl
+    schedule:
+      interval: daily

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2026 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Test
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: current
+          gradle-version: 7.6.5
           build-root-directory: tck-impl
           arguments: check -Pparsson.home=image/parsson-dist -Pparsson.impl=${{ matrix.test_suite }}
       - name: Upload test results


### PR DESCRIPTION
This just adds dependabot for the build files which have versioned dependencies. There are additional locations without versioned dependencies which likely should be versioned, but those can be added later.

I also had to pin the gradle version to 7.6.5, since the latest gradle version removed the `testReportDir` property that the build depends on.